### PR TITLE
TIKA-3128 | MOV file produces RuntimeException with 1.24.1, used to work with earlier version

### DIFF
--- a/isoparser/src/main/java/org/mp4parser/BasicContainer.java
+++ b/isoparser/src/main/java/org/mp4parser/BasicContainer.java
@@ -113,6 +113,8 @@ public class BasicContainer implements Container {
                 } else {
                     throw e;
                 }
+            } catch (RuntimeException e) {
+                return;
             }
         }
     }


### PR DESCRIPTION
Dear @tballison 

Could you please review this pull request?

This is a fix for [TIKA-3128](https://issues.apache.org/jira/browse/TIKA-3128) that adds a catch block for the `RuntimeException` that is thrown at https://github.com/tballison/mp4parser/blob/master/isoparser/src/main/java/org/mp4parser/AbstractBoxParser.java#L90 so the temporary file can be closed.

Thank you and best regards,
István